### PR TITLE
Update LVCE Editor server to 0.96.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@lvce-editor/eslint-config": "^18.0.0",
         "@lvce-editor/package-extension": "^3.2.0",
-        "@lvce-editor/server": "^0.70.20",
+        "@lvce-editor/server": "^0.96.12",
         "@lvce-editor/test-syntax-highlighting": "^1.3.0",
         "eslint": "^10.8.0",
         "execa": "^9.6.1",
@@ -1463,12 +1463,13 @@
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@lvce-editor/assert": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.5.1.tgz",
-      "integrity": "sha512-euS3PuVVjZy06bPFbgTz1yjQ0mY5BgWeYEDb9eQL2ncqYeap0ADy1D57nddlps1VkhHxj1g2ifXkLeIKLkQYJg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.9.0.tgz",
+      "integrity": "sha512-EPOXml+iWU38g0h71yv/nPaL1Xz/S72ICORPrR8shtoTqeoZmFzD8bH1dphr/xzYPaU97yEQo1Zen33aH111Uw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1480,16 +1481,16 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-2.10.0.tgz",
-      "integrity": "sha512-JZ2hu1ZUaMQDsAi3b1E1CYzHsTlLaPO8htYzH5gvN11sLkUPyI51BlP3yZOOs9tlwJa0itN5Wy2utPyiy+NscQ==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.25.0.tgz",
+      "integrity": "sha512-zgpiSbpQgA07YeiQSzApidBUB9DwenxBksXafJbehbxoNXfqNw2tDiZLifd5Y09PGz/cJhebVQCU2jvw55c4SA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.1.0.tgz",
-      "integrity": "sha512-HUyBfW/KvGcfgL+/H8H+c6ndC59mjpcnd9E8mutDzb+pI4issR1kNMeCA0qhKtMpBYTMZQwBJeBOk04quc2REg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.15.0.tgz",
+      "integrity": "sha512-Z9B7YS7KAzia8lI1XR4Grx5Rl+OX2ow5PuAePLh1n4gx5BB40VeJX7Jj9scOZRclUQQmhCkH6MQt28jhIXNQ4A==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1638,51 +1639,49 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.70.27",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.70.27.tgz",
-      "integrity": "sha512-jsUKw8hy6lGCB/RYWQaeNUEv518MZ8DX0P6/X98mSMg38gjHvDmOwzvHOXS0zWmHCmIMEdJMjlAPHHqBXEOxjw==",
+      "version": "0.96.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.96.12.tgz",
+      "integrity": "sha512-ERncFru8iwPAn8xHjHYBXnyOlDL5RU4uUbKFqCkvhfCG8v2Anmz1ilPK25kQxKXUAdTY7hzX5yylgeCACzH5DA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/rpc": "^5.4.0",
-        "@lvce-editor/verror": "^1.7.0",
-        "execa": "^9.6.1",
-        "got": "^14.6.6",
-        "minimist": "^1.2.8"
+        "@lvce-editor/assert": "^1.9.0",
+        "@lvce-editor/command": "^2.0.0",
+        "@lvce-editor/rpc": "^6.16.0",
+        "@lvce-editor/verror": "^1.7.0"
       },
       "engines": {
         "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-4.1.0.tgz",
-      "integrity": "sha512-DOIS+zaqwip/D/EktLUjG2G1O5N2F7g5bi70n2A3cOE1HeJ/68zlDxTV5gGO+G7kU1XVQWfJZTLB+KqujvUi4Q==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.11.0.tgz",
+      "integrity": "sha512-g1rGvTIBggaG9emayBczibKs+eOJgkOtbgp3TidDpuSwaX7uJotLBCGJNQyu6QhPPLskmkz1d5L4R+7bOzO/oA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "trash": "^10.0.1",
-        "ws": "^8.19.0"
+        "trash": "^10.1.1",
+        "ws": "^8.21.1"
       },
       "bin": {
         "file-system-process": "bin/fileSystemProcess.js"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/file-watcher-process": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-3.6.0.tgz",
-      "integrity": "sha512-EqijIFxF8PoYWhnYpCjwueOz202vid4NpfX1KbW79hkVKOCTe7BlWg5z17K8BbEpP7F0VIUnpiy5mwOoMPoqMw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.12.0.tgz",
+      "integrity": "sha512-3nLW4QWoH9eLpQ2bcKrawNxH7q2aLbdH0+E19kmlukOTM+HWmIj9dnJKr3zPiOKOnUjE/S0bZwB1gL+2Arbd4g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@lvce-editor/assert": "^1.4.0",
-        "chokidar": "^4.0.3"
+        "@lvce-editor/assert": "^1.5.1",
+        "chokidar": "^5.0.0"
       },
       "bin": {
         "file-watcher-process": "bin/fileWatcherProcess.js"
@@ -1692,24 +1691,25 @@
       }
     },
     "node_modules/@lvce-editor/ipc": {
-      "version": "14.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-14.7.0.tgz",
-      "integrity": "sha512-O/bt6OHcDPBmhkxQNpqA08EoxI8fpEvtpzye5O4GowH08/BvTAsRVocmPFioDNAL1no40vDg0eYFHg0frh1daQ==",
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.10.0.tgz",
+      "integrity": "sha512-iL4D4ou4iSOvVu2S7/L20JHDavOYcA0o2y8HDQYdksBkK52Dlbt4U1f96DC2FMfKl/6uTBuZFNL8hCapYZMa6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0"
+        "@lvce-editor/web-socket-server": "^2.1.0",
+        "ws": "^8.21.1"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@lvce-editor/json-rpc": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-7.2.0.tgz",
-      "integrity": "sha512-zslYa6B7qzsvVCbSXp9XYDRlPiRVVdFzen1lhNtRbJ4mZxp8IZnbj+YmM8VA4SKnr7m8Ebo9OWwN28sPzjInjQ==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.6.0.tgz",
+      "integrity": "sha512-T9zeMKn7Yk6QpMVY/RK5YzCp3VnG53jyHJ7gbC+CukuzlXMngj/TzR1mNkqEK8X3rFG+fxOAHrRKik+EE4cVAQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1929,96 +1929,109 @@
         "node": ">=22"
       }
     },
+    "node_modules/@lvce-editor/process-explorer": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.14.0.tgz",
+      "integrity": "sha512-PfJKcKPyqoxOhMJLXFMSTz9mrzWvK+rYgo3lZQQFBdEEwuC/m8laV4eppvKMucWsLJPfTCKFc1gtMqpXfSLUVw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "process-explorer": "bin/processExplorer.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@vscode/windows-process-tree": "^0.8.0"
+      }
+    },
     "node_modules/@lvce-editor/pty-host": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-7.1.0.tgz",
-      "integrity": "sha512-xHutTrUVgCeLv4MWpxdgIRd52/QDLgCxMoGzyiUk7gGRhqZue/WtCTU1aAL0z37bGEy6jbEg7N9nQ8L9Geb2Jg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.7.0.tgz",
+      "integrity": "sha512-wx/4AUOJJfPVBlgueNrF/lFODN2575KIwfE5vHCl26jFr8qWJHvmypv/91eoq4whA5wGzH+tjEvO4t4FT8GSrg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "dependencies": {
+        "@lvce-editor/command": "^2.0.0"
+      },
       "bin": {
         "pty-host": "bin/ptyHost.js"
       },
       "optionalDependencies": {
-        "node-pty": "^1.1.0-beta34"
+        "node-pty": "1.1.0-beta34"
       }
     },
     "node_modules/@lvce-editor/ripgrep": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-4.1.0.tgz",
-      "integrity": "sha512-J57lVXxRIbyuz1YwOi/hiUOMF6KDuOvht5OkhxVQOU971uv3j2t5bNdD6flq0hKmWESlr18p6sO0RTj8WMDIEA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-5.5.0.tgz",
+      "integrity": "sha512-k4VM7TG6/dENvTqiuJJZtSr4x9ZCzCnRsUVZFijVexPSvR0JmHY6MC1gAcLeb13kQbtL/CVJZNJ/sk64JSMSeg==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@lvce-editor/verror": "^1.7.0",
-        "execa": "^9.6.0",
-        "extract-zip": "^2.0.1",
-        "fs-extra": "^11.3.2",
-        "path-exists": "^5.0.0",
-        "tempy": "^3.1.0",
-        "xdg-basedir": "^5.1.0"
+        "@vscode/ripgrep": "1.18.0"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-5.6.0.tgz",
-      "integrity": "sha512-9C/sXlcgTtdSPkmS2xhWaRTcV29HiRI25PY2Ujkp74DVEBJ9tVO2UKz4ZE0XhIAeXojQBJG1wrk2Jmhj7dSiXg==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.16.0.tgz",
+      "integrity": "sha512-NK9k9/L3fWhwy3j3zrG0ffqHE+9SZ7DevvKcTkrrbgKAS3/L/pAJsTI9MuD8F+18oJEncjCmFTr26+CK3aPSgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^14.7.0",
-        "@lvce-editor/json-rpc": "^7.2.0"
+        "@lvce-editor/ipc": "^16.9.0",
+        "@lvce-editor/json-rpc": "^8.4.0",
+        "@lvce-editor/verror": "^1.7.0"
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-7.5.0.tgz",
-      "integrity": "sha512-i9C7T4RP4MdtSt5Zj9E81l5/iu2oOiX5UzRmYKkwhgfirpaaTDJ6UFe8ou126CZfAM8g/5IAB2jqQpiLx4jwzA==",
+      "version": "9.47.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.47.0.tgz",
+      "integrity": "sha512-EmtSPKK3XMt49CeyzLdSv+Ey4umTRIOOS64Inn/mJxCcmRe+bUi4+ik98PAf9Z+AfLiEV3d/Yjgs2IvBzvKJeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^2.8.0",
-        "@lvce-editor/rpc": "^5.2.0"
+        "@lvce-editor/constants": "^5.25.0",
+        "@lvce-editor/rpc": "^6.4.0"
       }
     },
     "node_modules/@lvce-editor/search-process": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-12.0.0.tgz",
-      "integrity": "sha512-svhY5/Y6ghdFynqa52ERZ4UDqzRGuZTtF1lVjpCgBpTTeB6+UCJbK0c7CE4Rt6stSJSKMKk+sKw0E3vcgUHwiw==",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.6.1.tgz",
+      "integrity": "sha512-XQfgR8TK0NN5tnkPnu5mlf7oEe66PwxbfJCCxjFD+XbXRtmYJZpUPitAjkZE5p1awl7RrQMJFUin8uC3mfulig==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "execa": "^9.6.0",
-        "ws": "^8.18.3"
+        "execa": "^9.6.1",
+        "ws": "^8.21.1"
       },
       "bin": {
         "search-process": "bin/searchProcess.js"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/ripgrep": "^4.0.0"
+        "@lvce-editor/ripgrep": "^5.2.0"
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.70.27",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.70.27.tgz",
-      "integrity": "sha512-TVZ+eABAuoQE/502EON2YBd1ft0F2nutakHEyCSva/792OSSvzsPLGKvCuRHx5rKVAhVRLuxDvcEhaxf8XqFJg==",
+      "version": "0.96.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.96.12.tgz",
+      "integrity": "sha512-XHvSr501fv/0MIbJXSzIMrLDq4djzRaLlHewKMlGtr57/Btz/atqVeb5g8wbsLS+HLdd9hQOVZM1LrGEvaHiRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.70.27",
-        "@lvce-editor/static-server": "0.70.27"
+        "@lvce-editor/shared-process": "0.96.12",
+        "@lvce-editor/static-server": "0.96.12"
       },
       "bin": {
         "server": "bin/server.js"
@@ -2028,46 +2041,48 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.70.27",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.70.27.tgz",
-      "integrity": "sha512-pKifbaf4RNGBtZldFHkzPwIP2RLuXFYLo+Us3SCVvOzKho6aATd9G59Kvv0PgvHXBnVc/RKJIoAKDfxTfSn1Cw==",
+      "version": "0.96.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.96.12.tgz",
+      "integrity": "sha512-ZdyOoNfEaHYPPEYDSuoKuMr9waXTzLwrAHxKj/sC27L9oLzP/CL2HW7iQosJRorTwTtfpm9l/k3y7KYrR8M6Tg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "1.5.1",
-        "@lvce-editor/extension-host-helper-process": "0.70.27",
-        "@lvce-editor/ipc": "14.7.0",
-        "@lvce-editor/json-rpc": "7.2.0",
+        "@lvce-editor/assert": "1.9.0",
+        "@lvce-editor/extension-host-helper-process": "0.96.12",
+        "@lvce-editor/ipc": "16.10.0",
+        "@lvce-editor/json-rpc": "8.6.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
         "@lvce-editor/pretty-error": "2.0.0",
-        "@lvce-editor/rpc-registry": "7.5.0",
+        "@lvce-editor/process-explorer": "3.14.0",
+        "@lvce-editor/rpc-registry": "9.47.0",
         "@lvce-editor/verror": "1.7.0",
         "is-object": "^1.0.2",
+        "markdown-it": "^15.0.0",
         "xdg-basedir": "^5.1.0"
       },
       "engines": {
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/embeds-process": "4.1.0",
-        "@lvce-editor/file-system-process": "4.1.0",
-        "@lvce-editor/file-watcher-process": "3.6.0",
+        "@lvce-editor/embeds-process": "4.15.0",
+        "@lvce-editor/file-system-process": "5.11.0",
+        "@lvce-editor/file-watcher-process": "4.12.0",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
-        "@lvce-editor/pty-host": "7.1.0",
-        "@lvce-editor/search-process": "12.0.0",
-        "@lvce-editor/typescript-compile-process": "4.1.0",
+        "@lvce-editor/pty-host": "8.7.0",
+        "@lvce-editor/search-process": "15.6.1",
+        "@lvce-editor/typescript-compile-process": "5.8.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
         "tmp-promise": "^3.0.3",
-        "trash": "^10.1.0"
+        "trash": "^10.1.1"
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.70.27",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.70.27.tgz",
-      "integrity": "sha512-I/aE0k9ZAb5n8m2Ys67a3KMLqIcONmotVI9fLkZyKe7sx0biauOAYvyAlBgPa38iSwELJQnbqwAmh9ds4PxZsw==",
+      "version": "0.96.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.96.12.tgz",
+      "integrity": "sha512-9hMcQbGGTJYknInPdjetwMT9lUe2n/nyAfoPM0rylzh9h1Is7FcQXdot+XQKz8Zx45j344niQC+z+O1nCZfwnw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2088,15 +2103,12 @@
       }
     },
     "node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-4.1.0.tgz",
-      "integrity": "sha512-tpWzwetxgvKCwNROOf89mqH6Hl4n1muvMQS55i75/t6JnntUTfMyVCMjf30jxe2+cZWjkHTLU7Wu7b2smzSyDw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.8.0.tgz",
+      "integrity": "sha512-kJ/NDVYT/KirvB/qAo8f0rVDJKgaRyCrYZ5c5W8B2bQ4iQLnQ68FHJcIKypRa6vN7bfI544xfl7laqMOhZZ28w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "ws": "^8.18.3"
-      },
       "bin": {
         "typescript-compile-process": "bin/typescriptCompileProcess.js"
       },
@@ -2830,6 +2842,7 @@
       "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       },
@@ -2900,7 +2913,8 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2933,17 +2947,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
-      }
-    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -2957,17 +2960,6 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.63.0",
@@ -3251,6 +3243,208 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vscode/ripgrep": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
+      "integrity": "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "optionalDependencies": {
+        "@vscode/ripgrep-darwin-arm64": "1.18.0",
+        "@vscode/ripgrep-darwin-x64": "1.18.0",
+        "@vscode/ripgrep-linux-arm": "1.18.0",
+        "@vscode/ripgrep-linux-arm64": "1.18.0",
+        "@vscode/ripgrep-linux-ia32": "1.18.0",
+        "@vscode/ripgrep-linux-ppc64": "1.18.0",
+        "@vscode/ripgrep-linux-riscv64": "1.18.0",
+        "@vscode/ripgrep-linux-s390x": "1.18.0",
+        "@vscode/ripgrep-linux-x64": "1.18.0",
+        "@vscode/ripgrep-win32-arm64": "1.18.0",
+        "@vscode/ripgrep-win32-ia32": "1.18.0",
+        "@vscode/ripgrep-win32-x64": "1.18.0"
+      }
+    },
+    "node_modules/@vscode/ripgrep-darwin-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
+      "integrity": "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-darwin-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
+      "integrity": "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
+      "integrity": "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
+      "integrity": "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
+      "integrity": "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ppc64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
+      "integrity": "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-riscv64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
+      "integrity": "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-s390x": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
+      "integrity": "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
+      "integrity": "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
+      "integrity": "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
+      "integrity": "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
+      "integrity": "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/windows-process-tree": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@vscode/windows-process-tree/-/windows-process-tree-0.8.0.tgz",
+      "integrity": "sha512-TI+h2GRwX+igD/YYJMQQVAFcsCNSg7Te2yYxQpKMzwto5RsJ8d2KKgOeur/p/6sAOQwZvopiTDOClyTHEn9MhQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "7.1.0"
+      }
+    },
     "node_modules/@zkochan/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@zkochan/rimraf/-/rimraf-3.0.2.tgz",
@@ -3301,6 +3495,23 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/argparse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
+      "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
       "version": "1.0.3",
@@ -3483,9 +3694,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3542,17 +3753,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -3589,6 +3789,7 @@
       "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=20"
       },
@@ -3612,6 +3813,7 @@
       "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -3622,6 +3824,7 @@
       "integrity": "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@types/http-cache-semantics": "^4.2.0",
         "get-stream": "^9.0.1",
@@ -3641,6 +3844,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -3696,17 +3900,17 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -3829,37 +4033,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypto-random-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
-      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "type-fest": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/crypto-random-string/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cspell-config-lib": {
@@ -4026,6 +4199,7 @@
       "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mimic-response": "^4.0.0"
       },
@@ -4237,6 +4411,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -4991,45 +5178,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5123,17 +5271,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -5264,6 +5401,7 @@
       "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 18"
       }
@@ -5278,9 +5416,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -5516,9 +5654,9 @@
       }
     },
     "node_modules/globby/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -5539,6 +5677,7 @@
       "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@sindresorhus/is": "^7.0.1",
         "byte-counter": "^0.1.0",
@@ -5566,6 +5705,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -5618,7 +5758,8 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
@@ -5626,6 +5767,7 @@
       "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -6184,6 +6326,26 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^3.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -6224,6 +6386,7 @@
       "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -6268,6 +6431,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.0.tgz",
+      "integrity": "sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^3.0.0",
+        "entities": "^8.0.0",
+        "linkify-it": "^6.0.0",
+        "mdurl": "^2.1.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^3.0.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/markdown-table": {
@@ -6545,6 +6736,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -7239,6 +7437,7 @@
       "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -7258,16 +7457,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/module-replacements": {
@@ -7343,17 +7532,20 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
+      }
     },
     "node_modules/node-pty": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
-      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "version": "1.1.0-beta34",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta34.tgz",
+      "integrity": "sha512-RraDtX9RS1G1I5iO7e4YIOIA4arzd4ZVCD4mZr7+szaNupoTg9fxDCRr0EanqS0Qlzgm3PIdHNbPmblJguJuyg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -7378,6 +7570,7 @@
       "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -7528,6 +7721,7 @@
       "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -7592,9 +7786,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -7712,14 +7906,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7874,6 +8060,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7902,6 +8098,7 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -7923,14 +8120,14 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -7992,22 +8189,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/rename-overwrite/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/reserved-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
@@ -8048,7 +8229,8 @@
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
@@ -8076,6 +8258,7 @@
       "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "lowercase-keys": "^3.0.0"
       },
@@ -8527,65 +8710,6 @@
         "streamx": "^2.12.5"
       }
     },
-    "node_modules/temp-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
-      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "node_modules/tempy": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.2.0.tgz",
-      "integrity": "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-stream": "^3.0.0",
-        "temp-dir": "^3.0.0",
-        "type-fest": "^2.12.2",
-        "unique-string": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/tempy/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/tempy/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/text-decoder": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
@@ -8813,13 +8937,12 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+    "node_modules/uc.micro": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
@@ -8829,23 +8952,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/unique-string": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
-      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "crypto-random-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9067,9 +9173,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9186,18 +9292,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ota-meshi"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@lvce-editor/eslint-config": "^18.0.0",
     "@lvce-editor/package-extension": "^3.2.0",
-    "@lvce-editor/server": "^0.70.20",
+    "@lvce-editor/server": "^0.96.12",
     "@lvce-editor/test-syntax-highlighting": "^1.3.0",
     "eslint": "^10.8.0",
     "execa": "^9.6.1",


### PR DESCRIPTION
Updates `@lvce-editor/server` to the frozen latest published version for this rollout.